### PR TITLE
Replace time with std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,3 @@ description = "Condition Variables (CondVars) made easy"
 homepage = "https://github.com/manuels/condition_variable.rs"
 license = " GPL-2.0"
 authors = ["Manuel Schölling <manuel.schoelling@gmx.de>"]
-
-[dependencies]
-time = "*"


### PR DESCRIPTION
Some room to follow the trend of moving _ms APIs to Duration APIs
